### PR TITLE
Make the status banner grey if status cannot be retrieved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### nova-dashboard, 0.19.1
+
+* The Galaxy status banner will now visually indicate if monitoring is inaccessible (thanks to John Duggan).
+
 ### nova-dashboard, 0.19.0
 
 * OAuth providers are now configured exclusively via the deployment environment (thanks to John Duggan).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "launcher-app"
-version = "0.19.0"
+version = "0.19.1"
 description = ""
 authors = ["Yakubov, Sergey <yakubovs@ornl.gov>", "Cage, Gregory <cagege@ornl.gov>", "Duggan, John <dugganjw@ornl.gov>"]
 readme = "README.md"

--- a/src/vue/src/components/StatusPanel.vue
+++ b/src/vue/src/components/StatusPanel.vue
@@ -15,7 +15,7 @@
                 {{ statusMessage(bannerStatus) }}
             </v-banner>
         </template>
-        <v-card>
+        <v-card v-if="showBanner">
             <v-card-title class="mb-2 px-0">{{ galaxyAlias }} System Status</v-card-title>
             <v-card-subtitle v-if="alertManager.monitoringUrl">
                 <v-btn :href="alertManager.monitoringUrl" target="_blank">
@@ -72,7 +72,7 @@
 </template>
 
 <script setup>
-import { onBeforeUnmount, onMounted, ref } from "vue"
+import { computed, onBeforeUnmount, onMounted, ref } from "vue"
 import AlertManager from "@/assets/js/alerts"
 
 const galaxyAlias = import.meta.env.VITE_GALAXY_ALIAS
@@ -80,7 +80,15 @@ const alertManager = new AlertManager()
 const bannerStatus = ref("success")
 let pollInterval = null
 
+const showBanner = computed(() => {
+    return bannerStatus.value !== "unavailable"
+})
+
 const statusColor = (status) => {
+    if (status === "unavailable") {
+        return "grey"
+    }
+
     if (status === "critical") {
         return "error"
     }
@@ -105,6 +113,10 @@ const statusIcon = (status) => {
 }
 
 const statusMessage = (status) => {
+    if (status === "unavailable") {
+        return `Unable to check ${galaxyAlias} status.`
+    }
+
     if (status === "critical") {
         return `Some ${galaxyAlias} systems are experiencing outages. Hover for details.`
     }
@@ -121,6 +133,7 @@ const checkStatus = async () => {
         await alertManager.update()
         bannerStatus.value = alertManager.getStatus()
     } catch (error) {
+        bannerStatus.value = "unavailable"
         console.error(`Failed to retrieve ${galaxyAlias} system status:`, error)
     }
 }


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
If the monitoring can't be retrieved, then we now show an appropriate error message with a grey background.

<img width="1493" height="295" alt="Screenshot 2025-10-29 at 3 38 43 PM" src="https://github.com/user-attachments/assets/7ecbc964-a90d-4223-9eb6-4308cbbe5e3a" />

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [ ] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
