### PR TITLE
Fix improper redirects when Galaxy is restarting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### nova-dashboard, 0.20.3
+
+* Fix redirection to invalid page when underlying Galaxy instance is restarted (thanks to John Duggan).
+
 ### nova-dashboard, 0.20.2
 
 * Using the browser's back button after using a launch URL will not revisit the launch URL (thanks to John Duggan).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-dashboard"
-version = "0.20.2"
+version = "0.20.3"
 description = ""
 authors = [
     { name = "Yakubov, Sergey", email = "yakubovs@ornl.gov" },

--- a/src/vue/src/stores/user.js
+++ b/src/vue/src/stores/user.js
@@ -13,6 +13,7 @@ export const useUserStore = defineStore("user", {
             delay: 2000,
             email: null,
             id: "",
+            initial_login_failed: false,
             is_admin: false,
             is_logged_in: false,
             ready: false
@@ -62,12 +63,13 @@ export const useUserStore = defineStore("user", {
                     window.location.reload()
                 }
 
+                this.initial_login_failed = true
                 this.ready = true
                 return
             }
             this.email = userData.email
 
-            if (this.id !== "" && this.id !== userData.id) {
+            if (this.initial_login_failed || (this.id !== "" && this.id !== userData.id)) {
                 window.location.reload()
             }
             this.id = userData.id

--- a/src/vue/src/views/CategoryView.vue
+++ b/src/vue/src/views/CategoryView.vue
@@ -82,7 +82,7 @@ onMounted(async () => {
     } else {
         router.replace({
             name: "not-found",
-            params: { catchAll: route.path.substring(1).split("/") }
+            params: { catchAll: route.path.substring(1).split("/").slice(1) }
         })
     }
 

--- a/src/vue/src/views/LaunchView.vue
+++ b/src/vue/src/views/LaunchView.vue
@@ -121,7 +121,7 @@ onMounted(async () => {
     if (targetTool.value === null) {
         router.replace({
             name: "not-found",
-            params: { catchAll: route.path.substring(1).split("/") }
+            params: { catchAll: route.path.substring(1).split("/").slice(1) }
         })
     }
 

--- a/src/vue/src/views/NotFoundView.vue
+++ b/src/vue/src/views/NotFoundView.vue
@@ -1,8 +1,19 @@
 <template>
     <v-container class="align-center d-flex h-100 justify-center" fluid>
         <v-card class="text-center" max-width="400">
-            <v-card-text>The content you requested could not be found.</v-card-text>
-            <v-btn to="/">Home</v-btn>
+            <v-banner v-if="job.galaxy_error" class="bg-error">
+                {{ job.galaxy_error }}
+            </v-banner>
+            <v-card-text v-else>
+                <p class="mb-4">The content you requested could not be found.</p>
+                <v-btn to="/">Home</v-btn>
+            </v-card-text>
         </v-card>
     </v-container>
 </template>
+
+<script setup>
+import { useJobStore } from "@/stores/job"
+
+const job = useJobStore()
+</script>


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
This fixes a few issues causing odd redirection behavior in the dashboard when Galaxy is restarting:

1. The not found page redirects were prepending /nova to paths that already included this.
2. Galaxy errors weren't being shown to users on the not found page.
3. There was no redirection after the restart was complete. 

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [ ] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
