### PR TITLE
Clone subservice children for status monitoring to fix instrument mount alert display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### nova-dashboard, 0.23.2
+
+* Fix instrument mount alert display error (thanks to John Duggan).
+
 ### nova-dashboard, 0.23.1
 
 * Fix tool launch error shortly after using exit button (thanks to John Duggan).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-dashboard"
-version = "0.23.1"
+version = "0.23.2"
 description = ""
 authors = [
     { name = "Yakubov, Sergey", email = "yakubovs@ornl.gov" },

--- a/src/vue/src/assets/js/alerts.js
+++ b/src/vue/src/assets/js/alerts.js
@@ -62,6 +62,10 @@ class Service {
         this.status = "success"
     }
 
+    clone() {
+        return new Service(this.name, this.children)
+    }
+
     reset() {
         this.alerts = []
         this.countText = ""
@@ -161,8 +165,11 @@ export default class AlertManager {
 
         const services = {}
         for (const target of targets) {
+            // If we don't clone each child, then the class instance will be shared between each subservice.
+            // That would cause an alert in one of the subservices to visually indicate an error in all of them.
+            const subServiceChildren = children.map((child) => child.clone())
             if (target.group === key) {
-                services[target.alias] = new Service(target.alias, children)
+                services[target.alias] = new Service(target.alias, subServiceChildren)
             }
         }
 


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
See the issue for the behavior before this change. Basically, nested status alerts (Instrument Data -> Compute Node -> Instrument Mount) are currently sharing class instances between them, so one Instrument Mount alert fires and shows up in all Compute Nodes. I've added a clone method to fix this.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [ ] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
